### PR TITLE
パッケージの説明はpackage-info.javaに書く

### DIFF
--- a/recipe.xml.ftl
+++ b/recipe.xml.ftl
@@ -21,6 +21,19 @@
     <instantiate from="src/app_package/SimpleActivity.java.ftl"
                    to="${escapeXmlAttribute(srcOut)}/${activityClass}.java" />
 
+    <instantiate from="src/app_package/fragment/package-info-fragment.java.ftl"
+                   to="${escapeXmlAttribute(srcOut)}/fragment/package-info.java" />
+    <instantiate from="src/app_package/manager/package-info-manager.java.ftl"
+                   to="${escapeXmlAttribute(srcOut)}/manager/package-info.java" />
+    <instantiate from="src/app_package/model/package-info-model.java.ftl"
+                   to="${escapeXmlAttribute(srcOut)}/model/package-info.java" />
+    <instantiate from="src/app_package/network/package-info-network.java.ftl"
+                   to="${escapeXmlAttribute(srcOut)}/network/package-info.java" />
+    <instantiate from="src/app_package/util/package-info-util.java.ftl"
+                   to="${escapeXmlAttribute(srcOut)}/util/package-info.java" />
+    <instantiate from="src/app_package/view/package-info-view.java.ftl"
+                   to="${escapeXmlAttribute(srcOut)}/view/package-info.java" />
+
     <open file="${escapeXmlAttribute(srcOut)}/${activityClass}.java" />
     <open file="${escapeXmlAttribute(resOut)}/layout/${layoutName}.xml" />
 </recipe>

--- a/root/src/app_package/fragment/package-info-fragment.java.ftl
+++ b/root/src/app_package/fragment/package-info-fragment.java.ftl
@@ -1,0 +1,4 @@
+/**
+ * パッケージの説明
+ */
+package ${packageName}.fragment;

--- a/root/src/app_package/manager/package-info-manager.java.ftl
+++ b/root/src/app_package/manager/package-info-manager.java.ftl
@@ -1,0 +1,4 @@
+/**
+ * パッケージの説明
+ */
+package ${packageName}.manager;

--- a/root/src/app_package/model/package-info-model.java.ftl
+++ b/root/src/app_package/model/package-info-model.java.ftl
@@ -1,0 +1,4 @@
+/**
+ * パッケージの説明
+ */
+package ${packageName}.model;

--- a/root/src/app_package/network/package-info-network.java.ftl
+++ b/root/src/app_package/network/package-info-network.java.ftl
@@ -1,0 +1,4 @@
+/**
+ * パッケージの説明
+ */
+package ${packageName}.network;

--- a/root/src/app_package/util/package-info-util.java.ftl
+++ b/root/src/app_package/util/package-info-util.java.ftl
@@ -1,0 +1,4 @@
+/**
+ * パッケージの説明
+ */
+package ${packageName}.util;

--- a/root/src/app_package/view/package-info-view.java.ftl
+++ b/root/src/app_package/view/package-info-view.java.ftl
@@ -1,0 +1,4 @@
+/**
+ * パッケージの説明
+ */
+package ${packageName}.view;


### PR DESCRIPTION
パッケージの説明はパッケージ(フォルダ)に**package-info.java**を作成して、そのファイル内にある
`パッケージの説明`をパッケージの説明文に書き換えます。
パッケージの役割や目的の説明が含まれていると、含まれているクラスなどを把握するために役立ちます。
